### PR TITLE
商品詳細表示機能_1

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  # before_action :item_params, only: :show
 
   def index
     @items = Item.order("created_at DESC")
@@ -18,10 +19,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
   def item_params
     params.require(:item).permit(
-      :item_name, :item_detail, :item_status_id, :category_id, :price, :shipping_charge_id, :shipping_day_id, :prefecture_id, :image
+      :item_name, :item_detail, :status_id, :category_id, :price, :shipping_charge_id, :shipping_day_id, :prefecture_id, :image
     ).merge(user_id: current_user.id)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
   end
   
   with_options presence: true, numericality: { other_than: 1, message: ' must be selected' } do
-    validates :item_status_id
+    validates :status_id
     validates :category_id
     validates :shipping_charge_id
     validates :shipping_day_id

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -53,7 +53,7 @@
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:item_status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,7 +34,7 @@
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_detail %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,37 +4,34 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+        <% if @item.present? %>
+          <div class="sold-out">
+            <span>Sold Out!!</span>
+          </div>
+        <% end %>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
-    </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥ #{@item.price.to_s(:delimited)}" %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_charge.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user.id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +40,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -102,9 +99,8 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20210322015324_create_items.rb
+++ b/db/migrate/20210322015324_create_items.rb
@@ -3,7 +3,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
     create_table :items do |t|
       t.string      :item_name,           null: false
       t.text        :item_detail,         null: false
-      t.integer     :item_status_id,      null: false
+      t.integer     :status_id,           null: false
       t.integer     :category_id,         null: false
       t.integer     :price,               null: false
       t.integer     :shipping_charge_id,  null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2021_03_22_023254) do
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "item_name", null: false
     t.text "item_detail", null: false
-    t.integer "item_status_id", null: false
+    t.integer "status_id", null: false
     t.integer "category_id", null: false
     t.integer "price", null: false
     t.integer "shipping_charge_id", null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :item do
     item_name           {Faker::Name.name}
     item_detail         {Faker::Lorem.sentence}
-    item_status_id      {2}
+    status_id      {2}
     category_id         {2}
     price               {1000}
     shipping_charge_id  {2}

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -39,12 +39,12 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include("Category  must be selected")
       end
       it '商品の状態が選択されていないと出品できない' do
-        @item.item_status_id = ""
+        @item.status_id = ""
         @item.valid?
         expect(@item.errors.full_messages).to include("Item status can't be blank", "Item status  must be selected")
       end
       it '商品の状態は無選択状態(id:1)では出品できない' do
-        @item.item_status_id = 1
+        @item.status_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("Item status  must be selected")
       end


### PR DESCRIPTION
# what
商品詳細表示機能の実装

# why
商品詳細ページを実装するため

### ご確認いただきたい動画
[ログイン状態の出品者が、自信で出品した商品の詳細ページに遷移](https://gyazo.com/464964ff18c7a7bef5b149431845b439)
[ログイン状態の非出品者が、販売中商品の詳細ページに遷移](https://gyazo.com/fb9af3a9e9f0c475da3cff179c6a0efb)
[ログアウト状態のユーザーが、商品詳細ページへ遷移](https://gyazo.com/2f6041414a623bb6a5b750dd28b9b8b3)